### PR TITLE
Fix package name to match directory structure - resolve FileNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError:
     long_description = "Custom Frappe Webshop UI based on organic fruits and vegetables template"
 
 setup(
-    name="webshop-ui",
+    name="webshop_ui",
     version="0.0.1",
     description="Custom Frappe Webshop UI based on organic fruits and vegetables template",
     long_description=long_description,


### PR DESCRIPTION
## Fix Package Name Directory Mismatch

This PR fixes the critical issue where the package name didn't match the directory structure, causing bench to look for files in the wrong location.

### Issue Resolved

**FileNotFoundError: [Errno 2] No such file or directory: './apps/webshop-ui/webshop-ui/__init__.py'**

- The package name in `setup.py` was `webshop-ui` (with hyphen)
- But the actual directory structure is `webshop_ui` (with underscore)
- This caused bench to look for files in `./apps/webshop-ui/webshop-ui/` instead of `./apps/webshop_ui/webshop_ui/`

### Fix Applied

- ✅ Changed package name in `setup.py` back to `webshop_ui` to match the actual directory structure
- ✅ This ensures bench looks for files in the correct location: `./apps/webshop_ui/webshop_ui/__init__.py`

### Frappe/ERPNext Convention

In Frappe apps, the package name should match the directory structure:
- Directory: `webshop_ui/`
- Package name: `webshop_ui`
- Module directory: `webshop_ui/webshop_ui/`

### Testing

After this fix, the installation should complete successfully without file path errors.
