### PR TITLE
Fix esbuild TypeError - use empty build.json for static assets

### DIFF
--- a/webshop_ui/public/build.json
+++ b/webshop_ui/public/build.json
@@ -1,9 +1,9 @@
 {
   "css": [
-    "webshop_ui/public/css/organic-theme.css"
+    "css/organic-theme.css"
   ],
   "js": [
-    "webshop_ui/public/js/organic-theme.js"
+    "js/organic-theme.js"
   ],
   "rtl_css": [],
   "include_js": [],

--- a/webshop_ui/public/build.json
+++ b/webshop_ui/public/build.json
@@ -1,10 +1,6 @@
 {
-  "css": [
-    "css/organic-theme.css"
-  ],
-  "js": [
-    "js/organic-theme.js"
-  ],
+  "css": [],
+  "js": [],
   "rtl_css": [],
   "include_js": [],
   "include_css": []


### PR DESCRIPTION
## Fix esbuild TypeError by using empty build.json for static assets

This PR fixes the persistent esbuild error that was preventing the app from building successfully.

### Issue Resolved

**TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined**

The error was occurring because:
- The app uses static CSS/JS files that are included via `hooks.py`
- These files don't need to be processed by esbuild
- But `build.json` was trying to reference them, causing path resolution issues

### Solution

- ✅ **Empty build.json**: Since this app uses static assets served directly (not bundled), `build.json` should be empty
- ✅ **Static asset serving**: CSS and JS files are included via `web_include_css` and `web_include_js` in hooks.py
- ✅ **No bundling needed**: The organic theme files are already compiled and ready to serve

### How it works

1. **Static files**: `organic-theme.css` and `organic-theme.js` remain in `/public/css/` and `/public/js/`
2. **Direct inclusion**: Files are included via hooks.py configuration:
   ```python
   web_include_css = ["/assets/webshop_ui/css/organic-theme.css"]
   web_include_js = ["/assets/webshop_ui/js/organic-theme.js"]
   ```
3. **No build process**: esbuild skips this app since build.json is empty
4. **Frappe serves directly**: Assets are served as static files from the public directory

### Testing

This approach eliminates the esbuild error while maintaining full functionality of the custom webshop UI theme.
