### PR TITLE
Fix invalid package.json deployment error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "webshop_ui",
+  "version": "0.0.1",
+  "description": "Custom Frappe Webshop UI - Static Assets Only",
+  "private": true,
+  "scripts": {
+    "build": "echo 'No build required - static assets only'",
+    "dev": "echo 'No dev server - static assets only'"
+  },
+  "keywords": [
+    "frappe",
+    "webshop",
+    "static-assets"
+  ],
+  "author": "Your Company",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Fix invalid package.json deployment error

This PR fixes the deployment error caused by an empty package.json file while maintaining the esbuild avoidance strategy.

### Issue Resolved

**Exception: ('App has invalid package.json file', 'webshop_ui', '/home/frappe/builds/...')**

The press deployment system requires a valid package.json file structure, but the previous fix made it empty to avoid esbuild processing.

### Solution

Created a **minimal but valid** package.json that:

1. ✅ **Satisfies deployment requirements** - Valid JSON structure with required fields
2. ✅ **Avoids esbuild processing** - No dependencies, no complex build configuration
3. ✅ **Indicates static assets only** - Clear description and build scripts
4. ✅ **Maintains functionality** - Combined with hooks.py build directives

### New package.json Structure

```json
{
  "name": "webshop_ui",
  "version": "0.0.1", 
  "description": "Custom Frappe Webshop UI - Static Assets Only",
  "private": true,
  "scripts": {
    "build": "echo 'No build required - static assets only'",
    "dev": "echo 'No dev server - static assets only'"
  },
  "keywords": ["frappe", "webshop", "static-assets"],
  "author": "Your Company",
  "license": "MIT"
}
```

### Key Features

- **No dependencies** - Prevents esbuild from trying to process anything
- **Private: true** - Indicates this is not a publishable package
- **Echo scripts** - Build commands that do nothing but satisfy tooling requirements
- **Clear description** - Indicates this is a static assets only app

### Expected Result

- ✅ Deployment system accepts the package.json file
- ✅ esbuild still skips processing (no dependencies + hooks.py directives)
- ✅ Static assets continue to work properly
- ✅ No build errors during installation
