### PR TITLE
Try minimal empty object build.json to fix esbuild TypeError

### DIFF
--- a/webshop_ui/public/build.json
+++ b/webshop_ui/public/build.json
@@ -1,1 +1,1 @@
-FILE_TO_DELETE
+{}

--- a/webshop_ui/public/build.json
+++ b/webshop_ui/public/build.json
@@ -1,7 +1,1 @@
-{
-  "css": [],
-  "js": [],
-  "rtl_css": [],
-  "include_js": [],
-  "include_css": []
-}
+FILE_TO_DELETE


### PR DESCRIPTION
## Try minimal empty object for build.json to fix persistent esbuild error

The empty arrays in build.json are still causing the TypeError. This PR tests if a minimal empty object `{}` works better.

### Issue
**TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined**

The error persists despite:
- Empty arrays in build.json
- Build disable directives in hooks.py
- Minimal package.json

### New Approach
Test if `build.json` with just `{}` (empty object) prevents the path resolution error in esbuild.

### Expected Result
- esbuild processes the empty object without trying to resolve undefined paths
- No TypeError during build process
- Static assets continue to work via hooks.py configuration

If this doesn't work, we may need to investigate the Frappe esbuild source code more deeply or find apps that successfully avoid esbuild processing.
